### PR TITLE
Fix an app crash due to a change of the CSS selector of the React app container

### DIFF
--- a/Messenger UWP/CSS/hide-broken-features.css
+++ b/Messenger UWP/CSS/hide-broken-features.css
@@ -1,0 +1,29 @@
+/* This file is part of Messenger UWP.
+Copyright (C) 2020 Sylvain Bruyère
+
+Messenger UWP is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+Messenger UWP is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Messenger UWP.  If not, see <https://www.gnu.org/licenses/>. */
+
+
+/* Hide the call room button */
+._30yy._94py {
+    display: none;
+}
+
+/* Hide the voice and video call buttons */
+._fl2 a {
+    width: auto !important;
+    height: auto !important;
+}
+._fl2 a [data-testid="startVoiceCall"], ._fl2 a [data-testid="startVideoCall"] {
+    display: none;
+}

--- a/Messenger UWP/CSS/master-detail.css
+++ b/Messenger UWP/CSS/master-detail.css
@@ -48,6 +48,11 @@ along with Messenger UWP.  If not, see <https://www.gnu.org/licenses/>. */
     height: 100%;
 }
 
+/* Fix the chat box that was covered by the container of GIF/audio recording/camera buttons on mobile */
+._5irm._7mkm {
+    z-index: 400;
+}
+
 /* Show the Messenger icon when there is nothing in detail view */
 ._1ut7 {
 	background-image: url("ms-appx-web:///Assets/SplashScreen.png");

--- a/Messenger UWP/JavaScript/messenger-pwa/selectors.js
+++ b/Messenger UWP/JavaScript/messenger-pwa/selectors.js
@@ -15,7 +15,7 @@
 
 
 MessengerPWA.Selectors = {
-    ROOT_CONTAINER: "_li",
+    ROOT_CONTAINER: "._2sdm > ._li",
     MASTER_DETAIL_CONTAINER: "_4sp8",
 
     MASTER_VIEW: "_1enh",

--- a/Messenger UWP/JavaScript/messenger-pwa/views/master-detail.js
+++ b/Messenger UWP/JavaScript/messenger-pwa/views/master-detail.js
@@ -18,7 +18,7 @@ MessengerPWA.Views.MasterDetail = (function () {
     var self = {};
 
     var container = DOM.getByClass(MessengerPWA.Selectors.MASTER_DETAIL_CONTAINER);
-    var root = DOM.getByClass(MessengerPWA.Selectors.ROOT_CONTAINER);
+    var root = DOM.getBySelector(MessengerPWA.Selectors.ROOT_CONTAINER);
     var rootComponent = null;
 
     /**

--- a/Messenger UWP/Messenger UWP.csproj
+++ b/Messenger UWP/Messenger UWP.csproj
@@ -211,6 +211,7 @@
     <None Include="CSS\cancel-media-queries.css" />
     <None Include="CSS\cards.css" />
     <None Include="CSS\dialogs.css" />
+    <None Include="CSS\hide-broken-features.css" />
     <None Include="CSS\info-panel.css" />
     <None Include="CSS\master-detail.css" />
     <None Include="CSS\picture-album.css" />

--- a/Messenger UWP/Package.appxmanifest
+++ b/Messenger UWP/Package.appxmanifest
@@ -21,7 +21,7 @@ along with Messenger UWP.  If not, see <https://www.gnu.org/licenses/>. -->
     xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
     IgnorableNamespaces="uap uap5 mp">
 
-    <Identity Name="53330SSoft.MessengerUWP" Publisher="CN=C2230194-F9C4-4811-936E-C2BD4208FD18" Version="0.3.0.0" />
+    <Identity Name="53330SSoft.MessengerUWP" Publisher="CN=C2230194-F9C4-4811-936E-C2BD4208FD18" Version="0.3.1.0" />
     <mp:PhoneIdentity PhoneProductId="59435353-1be9-48a9-aaba-cfb9634454a1" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
     <Properties>

--- a/Messenger UWP/Properties/AssemblyInfo.cs
+++ b/Messenger UWP/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.0.0")]
-[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyVersion("0.3.1.0")]
+[assembly: AssemblyFileVersion("0.3.1.0")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
fix(react-root): update the CSS selector used to retrieve the React instance (which caused app crash)
fix(chat-box): ensure that the chat box is not covered by the container of GIF/audio recording/camera buttons on mobile (#8)
fix(call): hide call buttons as this feature is broken